### PR TITLE
Added RoboTablets to dxmProducts

### DIFF
--- a/javascript/dxmcalculator.js
+++ b/javascript/dxmcalculator.js
@@ -12,7 +12,7 @@ window.onload =  () => {
     { value: 15, name: 'Robitussin Gelcaps (15 mg caps)', type: 'HBr' },
     { value: 1, name: 'Pure (mg)', type: 'Pure' },
     { value: 30, name: '30mg Gelcaps (30 mg caps)', type: 'HBr' },
-    { value: 38.94, name: 'RoboTablets (30 mg tablets)', type: 'Pure' }
+    { value: 40.9322, name: 'RoboTablets (30 mg tablets)', type: 'Pure' }
   ];
 
   // Populate automode's select options

--- a/javascript/dxmcalculator.js
+++ b/javascript/dxmcalculator.js
@@ -12,9 +12,10 @@ window.onload =  () => {
     { value: 15, name: 'Robitussin Gelcaps (15 mg caps)', type: 'HBr' },
     { value: 1, name: 'Pure (mg)', type: 'Pure' },
     { value: 30, name: '30mg Gelcaps (30 mg caps)', type: 'HBr' },
+    { value: 38.94, name: 'RoboTablets (30 mg tablets)', type: 'Pure' }
   ];
 
-  // Populate automode's select options 
+  // Populate automode's select options
   let autoModeOpions = document.getElementById('autoSubstance').options;
 
   dxmProducts.map((product, i) => {


### PR DESCRIPTION
RoboTablets (r30) is a popular and fairly new product [that only contains freebase DXM](https://www.reddit.com/r/dxm/comments/jcds6h/we_need_a_discussion_about_the_new_robotablets/). Because it's entirely freebase dxm, people overestimate their doses thinking it's like dxm HBr. It deserves a spot on the calculator!